### PR TITLE
Fix migration issue

### DIFF
--- a/ebpub/ebpub/db/migrations/0026_make_unique_lookup_names.py
+++ b/ebpub/ebpub/db/migrations/0026_make_unique_lookup_names.py
@@ -9,7 +9,7 @@ class Migration(DataMigration):
     def forwards(self, orm):
         "Write your forwards methods here."
         # Ensure names are unique.
-        for lname in orm['db.lookup'].objects.all().distinct('name').values_list('name'):
+        for lname in orm['db.lookup'].objects.all().distinct('name'),order_by('name').values_list('name'):
             lname = lname[0]
             for sf in orm['db.schemafield'].objects.all():
                 with_name = orm['db.lookup'].objects.filter(name=lname, schema_field=sf)

--- a/ebpub/ebpub/db/migrations/0026_make_unique_lookup_names.py
+++ b/ebpub/ebpub/db/migrations/0026_make_unique_lookup_names.py
@@ -9,7 +9,7 @@ class Migration(DataMigration):
     def forwards(self, orm):
         "Write your forwards methods here."
         # Ensure names are unique.
-        for lname in orm['db.lookup'].objects.all().distinct('name'),order_by('name').values_list('name'):
+        for lname in orm['db.lookup'].objects.all().distinct('name').order_by('name').values_list('name'):
             lname = lname[0]
             for sf in orm['db.schemafield'].objects.all():
                 with_name = orm['db.lookup'].objects.filter(name=lname, schema_field=sf)


### PR DESCRIPTION
I got an error when running my initial migrations.
One of the migrations didn't have an order_by that Postgres wanted.

This change fixes this error:

Error in migration: db:0026_make_unique_lookup_names
DatabaseError: SELECT DISTINCT ON expressions must match initial ORDER BY expressions
LINE 1: SELECT DISTINCT ON ("db_lookup"."name") "db_lookup"."name", ...
